### PR TITLE
Performance tweaking for stdStringBuilder

### DIFF
--- a/src/WIP/stdStringBuilder.cls
+++ b/src/WIP/stdStringBuilder.cls
@@ -62,10 +62,26 @@ Attribute VB_Exposed = False
 '    renderHTML(sb)
 '
 'Which significantly improves maintainability of the code.
+Option Explicit
 
+' must be >= 2
+Private Const DEFAULT_MINIMUM_CAPACITY As Long = 16
+
+' StaticStringBuilder from https://github.com/sihlfall/vba-stringbuilder
+' Code copied in here in order to keep everything in one file.
+Private Type SsbTy
+  Active As Integer            ' index of the currently active buffer (0 or 1)
+  Buffer(0 To 1) As String     ' .Buffer(.Active) is the currently active buffer
+  Capacity As Long             ' current allocated capacity in characters
+  Length As Long               ' current length of the string, in characters
+  MinimumCapacity As Long      ' minimum capacity set (>= 2)
+End Type
+
+Private InjectionVariablesDictionary As Object
 Private Tainted As Boolean
 Private ProcessedString As String
-Public RawString As String
+Private Ssb As SsbTy
+
 Public JoinStr As String
 Public TrimBehaviour As TrimBehaviourEnum
 Public Enum TrimBehaviourEnum
@@ -74,19 +90,42 @@ Public Enum TrimBehaviourEnum
   RTrim
   Trim
 End Enum
-Public InjectionVariables As Object
+
+Public Property Get InjectionVariables() As Object
+  If InjectionVariablesDictionary Is Nothing Then Set InjectionVariablesDictionary = CreateObject("Scripting.Dictionary")
+  Set InjectionVariables = InjectionVariablesDictionary
+End Property
+
+Public Property Get MinimumCapacity() As Long
+  MinimumCapacity = Ssb.MinimumCapacity
+End Property
+Public Property Let MinimumCapacity(desiredMinimumCapacity As Long)
+  If desiredMinimumCapacity >= 2 Then Ssb.MinimumCapacity = desiredMinimumCapacity Else Ssb.MinimumCapacity = 2
+End Property
+
 Public Property Get Str() As String
 Attribute Str.VB_UserMemId = 0
   If Tainted Then Call RefreshFromRaw
   Str = ProcessedString
 End Property
 Public Property Let Str(s As String)
-  RawString = s
+  Dim sLength As Long
+  With Ssb
+    sLength = Len(s)
+    ' We accept only 100% space overhead.
+    If .Capacity < sLength Or (2 * sLength < .Capacity And .Capacity > .MinimumCapacity) Then ClearReserve sLength
+    If sLength > 0 Then Mid$(.Buffer(.Active), 1, sLength) = s
+    .Length = sLength
+  End With
+  
+  Tainted = True
 End Property
 
 'Appends the string parsed to the main string Str
 Public Function Append(s As String) As Variant
 Attribute Append.VB_UserMemId = -5
+  Dim Length As Long, lengthJoin As Long, nRequired As Long
+  
   'Trim based on TrimBehaviour
   Select Case TrimBehaviour
     Case TrimBehaviourEnum.LTrim
@@ -98,7 +137,15 @@ Attribute Append.VB_UserMemId = -5
   End Select
   
   'Build String
-  RawString = RawString & JoinStr & s
+  With Ssb
+    Length = Len(s): lengthJoin = Len(JoinStr)
+    If Length + lengthJoin = 0 Then Exit Function
+    nRequired = .Length + Length + lengthJoin
+    If nRequired > .Capacity Then SwitchToLargerBuffer nRequired
+    If lengthJoin > 0 Then Mid$(.Buffer(.Active), .Length + 1, lengthJoin) = JoinStr
+    If Length > 0 Then Mid$(.Buffer(.Active), .Length + lengthJoin + 1, Length) = s
+    .Length = nRequired
+  End With
   
   'Set tainted
   Tainted = True
@@ -111,7 +158,7 @@ End Function
 
 Public Function Test()
   Dim sb As Object
-  Set sb = stdStringBuilder.Create()
+  Set sb = Create()
   sb.JoinStr = "-"
   sb.Str = "Start"
   sb.TrimBehaviour = RTrim
@@ -129,19 +176,67 @@ End Function
 '==============================
 
 Private Sub RefreshFromRaw()
-  ProcessedString = RawString
+  With Ssb
+    ProcessedString = Left$(.Buffer(.Active), .Length)
+  End With
   
   'Replace keys
   Dim key
-  For Each key In InjectionVariables.Keys()
-    ProcessedString = VBA.Replace(ProcessedString, key, InjectionVariables(key))
-  Next
+  If Not InjectionVariablesDictionary Is Nothing Then
+    For Each key In InjectionVariablesDictionary.Keys()
+      ProcessedString = VBA.Replace(ProcessedString, key, InjectionVariables(key))
+    Next
+  End If
   
   'No longer tainted
   Tainted = False
 End Sub
-Private Sub Class_Initialize()
-  Str = ""
-  JoinStr = vbCrLf
-  Set InjectionVariables = CreateObject("Scripting.Dictionary")
+
+Private Sub ClearReserve(ByVal nRequired As Long)
+  ' Clear everything
+  ' Allocate a buffer that is able to hold nRequired characters.
+  ' The new buffer size is calculated by repeatedly growing the minimum capacity by 50%.
+  With Ssb
+    .Active = 0
+    .Length = 0
+    .Buffer(1) = vbNullString
+    If nRequired > 0 Then
+      .Capacity = .MinimumCapacity
+      Do
+        If .Capacity >= nRequired Then Exit Do
+        .Capacity = .Capacity + .Capacity \ 2
+      Loop
+      .Buffer(0) = String(.Capacity, 0)
+    Else
+      .Capacity = 0
+      .Buffer(0) = vbNullString
+    End If
+  End With
+  Tainted = False
+  ProcessedString = vbNullString
 End Sub
+
+Private Sub SwitchToLargerBuffer(ByVal nRequired As Long)
+  ' Allocate buffer that is able to hold nRequired characters.
+  ' The new buffer size is calculated by repeatedly growing the current size by 50%.
+  ' Copy string over to the new buffer.
+  ' Deallocate the old buffer.
+  With Ssb
+    If .Capacity < .MinimumCapacity Then .Capacity = .MinimumCapacity
+    Do
+      If .Capacity >= nRequired Then Exit Do
+      .Capacity = .Capacity + .Capacity \ 2
+    Loop
+    .Buffer(1 - .Active) = String(.Capacity, 0)
+    Mid$(.Buffer(1 - .Active), 1, .Length) = .Buffer(.Active)
+    .Buffer(.Active) = vbNullString
+    .Active = 1 - .Active
+  End With
+End Sub
+
+Private Sub Class_Initialize()
+  Ssb.MinimumCapacity = DEFAULT_MINIMUM_CAPACITY
+  JoinStr = vbCrLf
+End Sub
+
+

--- a/tests/Main.bas
+++ b/tests/Main.bas
@@ -16,4 +16,5 @@ Sub MainTestAll()
     Call stdProcessTests.testAll
     Call stdWebSocketTests.testAll
     Call stdPerformanceTests.testAll
+    Call stdStringBuilderTests.testAll
 End Sub

--- a/tests/stdStringBuilderTests.bas
+++ b/tests/stdStringBuilderTests.bas
@@ -1,0 +1,231 @@
+Attribute VB_Name = "stdStringBuilderTests"
+Sub testAll()
+    Test.Topic "stdStringBuilder"
+
+    test_stdStringBuilder_Append_001
+    test_stdStringBuilder_Append_002
+    test_stdStringBuilder_Append_003
+    test_stdStringBuilder_Append_004
+    test_stdStringBuilder_Append_010
+    test_stdStringBuilder_Str_001
+    test_stdStringBuilder_Str_002
+    test_stdStringBuilder_Str_003
+    test_stdStringBuilder_Str_050
+    test_stdStringBuilder_Str_051
+    test_stdStringBuilder_Str_052
+    test_stdStringBuilder_Str_053
+    test_stdStringBuilder_Str_054
+    test_stdStringBuilder_Str_055
+    test_stdStringBuilder_Str_056
+    test_stdStringBuilder_Str_057
+    test_stdStringBuilder_Str_060
+    test_stdStringBuilder_Demo
+End Sub
+
+Private Sub test_stdStringBuilder_Append_001()
+    Test.Topic "stdStringBuilder: Test appending several times, staying within minimum buffer size"
+    Dim sb As stdStringBuilder
+    Set sb = stdStringBuilder.Create()
+    sb.JoinStr = vbNullString
+    Test.Assert "Initially", "" = sb.Str
+    sb.Append ("xyz")
+    Test.Assert "After first append",  "xyz" = sb.Str
+    sb.Append ("abc")
+    Test.Assert "After second append", "xyzabc" = sb.Str
+End Sub
+
+Private Sub test_stdStringBuilder_Append_002()
+    Test.Topic "stdStringBuilder: Appending several times, exceeding minimum buffer size"
+    Dim sb As stdStringBuilder
+    Set sb = stdStringBuilder.Create()
+    sb.JoinStr = vbNullString
+    sb.Append (String(100, "a"))
+    Test.Assert "After first append", String(100, "a") = sb.Str
+    sb.Append (String(200, "x"))
+    Test.Assert "After second append", String(100, "a") & String(200, "x") = sb.Str
+End Sub
+
+Private Sub test_stdStringBuilder_Append_003()
+    Test.Topic "stdStringBuilder: Appending several times, exceeding minimum buffer size"
+    Dim sb As stdStringBuilder
+    Set sb = stdStringBuilder.Create()
+    sb.JoinStr = vbNullString
+    Test.Assert "Initially", "" = sb.Str
+    sb.Append (String(100, "a"))
+    Test.Assert "After first append", String(100, "a") = sb.Str
+    sb.Append (String(200, "x"))
+    Test.Assert "After second append", String(100, "a") & String(200, "x") = sb.Str
+    sb.Append (String(1000, "y"))
+    Test.Assert "After third append", String(100, "a") & String(200, "x") & String(1000, "y") = sb.Str
+End Sub
+
+Private Sub test_stdStringBuilder_Append_004()
+    Test.Topic "stdStringBuilder: Appending vbNullString to empty buffer"
+    Dim sb As stdStringBuilder
+    Set sb = stdStringBuilder.Create()
+    sb.JoinStr = vbNullString
+    Test.Assert "Initially", "" = sb.Str
+    sb.Append (vbNullString)
+    Test.Assert "After append", "" = sb.Str
+End Sub
+
+Private Sub test_stdStringBuilder_Append_010()
+    Test.Topic "stdStringBuilder: Calling with bracket notation works"
+    Dim sb As Object
+    Set sb = stdStringBuilder.Create()
+    sb.JoinStr = vbNullString
+    Test.Assert "Initially", "" = sb.Str
+    sb.[abcdef]
+    sb.[ghijkl]
+    Test.Assert "After appending", "abcdefghijkl" = sb.Str
+End Sub
+
+Private Sub test_stdStringBuilder_Str_001()
+    Test.Topic "stdStringBuilder: Initially an empty string is returned"
+    Dim sb As stdStringBuilder
+    Set sb = stdStringBuilder.Create()
+    sb.JoinStr = vbNullString
+    Test.Assert "Initially", "" = sb.Str
+End Sub
+
+Private Sub test_stdStringBuilder_Str_002()
+    Test.Topic "stdStringBuilder: The correct string is returned from buffer 0"
+    Dim sb As stdStringBuilder
+    Set sb = stdStringBuilder.Create()
+    sb.JoinStr = vbNullString
+    sb.Append (String(15, "a"))
+    Test.Assert "After appending", "aaaaaaaaaaaaaaa" = sb.Str
+End Sub
+
+Private Sub test_stdStringBuilder_Str_003()
+    Test.Topic "stdStringBuilder: The correct string is returned from buffer 1"
+    Dim sb As stdStringBuilder
+    Set sb = stdStringBuilder.Create()
+    sb.JoinStr = vbNullString
+    sb.Append (String(15, "a"))
+    sb.Append (String(8, "b"))
+    Test.Assert "After appending", "aaaaaaaaaaaaaaabbbbbbbb" = sb.Str
+End Sub
+
+Private Sub test_stdStringBuilder_Str_050()
+    Test.Topic "stdStringBuilder: Str is default get property"
+    Dim sb As stdStringBuilder, s As String
+    Set sb = stdStringBuilder.Create()
+    sb.JoinStr = vbNullString
+    sb.Append ("xyzabc")
+    s = sb
+    Test.Assert "After appending", "xyzabc" = s
+End Sub
+
+Private Sub test_stdStringBuilder_Str_051()
+    Test.Topic "stdStringBuilder: Str is default let property"
+    Dim sb As stdStringBuilder
+    Set sb = stdStringBuilder.Create()
+    sb.JoinStr = vbNullString
+    sb.Append ("xyzabc")
+    sb = "hello world"
+    Test.Assert "After appending", "hello world" = sb.Str
+End Sub
+
+Private Sub test_stdStringBuilder_Str_052()
+    Test.Topic "stdStringBuilder: Assigning a short string to Str works if current content is a rather long string"
+    Dim sb As stdStringBuilder
+    Set sb = stdStringBuilder.Create()
+    sb.JoinStr = vbNullString
+    sb.Append (String(10000, "a"))
+    sb = String(50, "b")
+    Test.Assert "After appending", String(50, "b") = sb.Str
+End Sub
+
+Private Sub test_stdStringBuilder_Str_053()
+    Test.Topic "stdStringBuilder: After a short string has been assigned to a StringBuilder containing a rather long string, appending works"
+    Dim sb As stdStringBuilder
+    Set sb = stdStringBuilder.Create()
+    sb.JoinStr = vbNullString
+    sb.Append (String(10000, "a"))
+    sb = String(50, "b")
+    sb.Append (String(2000, "c"))
+    Test.Assert "After appending", String(50, "b") & String(2000, "c") = sb.Str
+End Sub
+
+Private Sub test_stdStringBuilder_Str_054()
+    Test.Topic "stdStringBuilder: Assigning the empty string works"
+    Dim sb As stdStringBuilder
+    Set sb = stdStringBuilder.Create()
+    sb.JoinStr = vbNullString
+    sb.Append (String(10000, "a"))
+    sb = ""
+    Test.Assert "After assigning", "" = sb.Str
+    sb.Append (String(2000, "c"))
+    Test.Assert "After appending", String(2000, "c") = sb.Str
+End Sub
+
+Private Sub test_stdStringBuilder_Str_055()
+    Test.Topic "stdStringBuilder: Assigning the null string works"
+    Dim sb As stdStringBuilder
+    Set sb = stdStringBuilder.Create()
+    sb.JoinStr = vbNullString
+    sb.Append (String(10000, "a"))
+    sb = vbNullString
+    Test.Assert "After assigning", "" = sb.Str
+    sb.Append (String(2000, "c"))
+    Test.Assert "After appending", String(2000, "c") = sb.Str
+End Sub
+
+Private Sub test_stdStringBuilder_Str_056()
+    Test.Topic "stdStringBuilder: Correctly appends single characters after a short string has been assigned to a StringBuilder containing a long string"
+    Dim sb As stdStringBuilder, i As Integer
+    Set sb = stdStringBuilder.Create()
+    sb.JoinStr = vbNullString
+    sb.Append (String(10000, "a"))
+    sb = "abc"
+    Test.Assert "After assigning", "abc" = sb.Str
+    For i = 1 To 2500
+        sb.Append ("d")
+    Next
+    Test.Assert "After appending", "abc" & String(2500, "d") = sb.Str
+End Sub
+
+Private Sub test_stdStringBuilder_Str_057()
+    Test.Topic "stdStringBuilder: Correctly appends single characters after a long string has been assigned to a StringBuilder containing a short string"
+    Dim sb As stdStringBuilder, i As Integer
+    Set sb = stdStringBuilder.Create()
+    sb.JoinStr = vbNullString
+    sb.Append ("aa")
+    Test.Assert "Before assigning", "aa" = sb.Str
+    sb.Str = String(10000, "b")
+    Test.Assert "After assigning", String(10000, "b") = sb.Str
+    For i = 1 To 25000
+        sb.Append ("d")
+    Next
+    Test.Assert "After appending", String(10000, "b") & String(25000, "d") = sb.Str
+End Sub
+
+Private Sub test_stdStringBuilder_Str_060()
+    Test.Topic "stdStringBuilder: Correctly appends single characters after setting MinimumCapacity = 0"
+    Dim sb As stdStringBuilder, i As Integer
+    Set sb = stdStringBuilder.Create()
+    sb.JoinStr = vbNullString
+    sb.MinimumCapacity = 0
+    Test.Assert "MinimumCapacity delivers 2 after being set to 0", 2& = sb.MinimumCapacity
+    For i = 1 To 1000
+        sb.Append ("d")
+    Next
+    Test.Assert "After appending", String(1000, "d") = sb.Str
+End Sub
+
+Private Sub test_stdStringBuilder_Demo()
+    Test.Topic "stdStringBuilder: Demo code"
+    Dim sb As Object
+    Set sb = stdStringBuilder.Create()
+    sb.JoinStr = "-"
+    sb.Str = "Start"
+    sb.TrimBehaviour = RTrim
+    sb.InjectionVariables.Add "@1", "cool"
+    sb.[This is a really cool multi-line    ]
+    sb.[string which can even include       ]
+    sb.[symbols like " ' # ! / \ without    ]       
+    sb.[causing compiler errors!!           ]
+    sb.[also this has @1 variable injection!]
+    Test.Assert "Correct result", "Start-This is a really cool multi-line-string which can even include-symbols like "" ' # ! / \ without-causing compiler errors!!-also this has cool variable injection!" = sb.Str
+End Sub


### PR DESCRIPTION
Here is the Pull Request. I have made the changes to stdStringBuilder and added some tests.

Had some problems running the tests, which I think are unrelated to StringBuilder:
1.) Use of isNumber in stdArrayTests and stdEnumeratorTests. Replacing by isNumeric fixed the issue.
2.) Some Debug.Assert False statements in stdWebSocket and stdWebSocketNew. Commenting out made the tests run.
