### PR TITLE
Update Enforce-CRLF to v1.1.3

### DIFF
--- a/.github/workflows/enforce_crlf.yml
+++ b/.github/workflows/enforce_crlf.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Enforce CRLF action
-      uses: DecimalTurn/Enforce-CRLF@08706ea4cc4a3de32d8b3c769686355a22d69e84 #v1.1.2
+      uses: DecimalTurn/Enforce-CRLF@ec751ecfeb0e0cf51d19f295435c7a6ec10bac15 #v1.1.3
       with:
         extensions: .bas, .frm, .cls
         do-checkout: true


### PR DESCRIPTION
Reason: GitHub depreciated v3 for `actions/upload-artifact`, so actions have to move to v4.

Release notes: https://github.com/DecimalTurn/Enforce-CRLF/releases/tag/v1.1.3